### PR TITLE
Add scheduler plugins helm chart

### DIFF
--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: scheduler-plugins
+description: deploy scheduler plugin as a second scheduler in cluster
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.0.1"

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chart.labels" -}}
+helm.sh/chart: {{ include "chart.chart" . }}
+{{ include "chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.plugins.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.scheduler.name }}-scheduler-config
+data:
+  scheduler-config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1
+    kind: KubeSchedulerConfiguration
+    leaderElection:
+      leaderElect: {{ .Values.scheduler.leaderElect }}
+      resourceNamespace: {{ .Release.Namespace }}
+      resourceName: {{ .Values.scheduler.name }}
+    profiles:
+    # Compose all plugins in one profile
+    - schedulerName: {{ .Values.scheduler.name }}
+      plugins:
+        multiPoint:
+          enabled:
+          {{- range $.Values.plugins.enabled }}
+          - name: {{ title .name }}
+            weight: {{ .weight }}
+          {{- end }}
+          disabled:
+          {{- range $.Values.plugins.disabled }}
+          - name: {{ title .name }}
+          {{- end }}
+      {{- if $.Values.pluginConfig }}
+      pluginConfig: {{ toYaml $.Values.pluginConfig | nindent 6 }}
+      {{- end }}
+
+{{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.scheduler.name }}
+  labels:
+    app.kubernetes.io/component: scheduler
+    app.kubernetes.io/created-by: scheduler-plugins
+    app.kubernetes.io/part-of: scheduler-plugins
+    control-plane: scheduler
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.scheduler.replicaCount }}
+  selector:
+    matchLabels:
+      control-plane: scheduler
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        control-plane: scheduler
+        {{- include "chart.selectorLabels" . | nindent 8 }}
+      annotations:
+        kubectl.kubernetes.io/default-container: scheduler
+    spec:
+      {{- with .Values.scheduler.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      serviceAccountName:  {{ .Values.scheduler.name }}
+      containers:
+      - command: {{- toYaml .Values.scheduler.command | nindent 8 }}
+        args:
+        - --config=/etc/kubernetes/scheduler-config.yaml
+        image: {{ .Values.scheduler.image.repository }}:{{ .Values.scheduler.image.tag | default .Chart.AppVersion }}
+        {{- with .Values.scheduler.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+          initialDelaySeconds: 15
+        name: scheduler
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+        {{- with .Values.scheduler.resources }}
+        resources: {{- toYaml . | nindent 10 }}
+        {{- end }}
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - name: scheduler-config
+          mountPath: /etc/kubernetes
+          readOnly: true
+      hostNetwork: false
+      hostPID: false
+      volumes:
+      - name: scheduler-config
+        configMap:
+          name: {{ .Values.scheduler.name }}-scheduler-config
+      {{- with .Values.scheduler.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -1,0 +1,66 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.scheduler.name }}-plugins
+rules:
+{{- /* resources need to be updated with the scheduler plugins used */}}
+{{- range .Values.plugins.enabled }}
+  {{- if eq .name "ResourceFungibility" }}
+- apiGroups: [ "llmaz.io" ]
+  resources: [ "openmodels" ]
+  verbs: [ "get" ]
+  {{- end }}
+{{- end }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.scheduler.name }}-plugins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.scheduler.name }}-plugins
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.scheduler.name }}
+  namespace: {{ .Release.Namespace }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.scheduler.name }}-kube-scheduler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-scheduler
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.scheduler.name }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.scheduler.name }}-kube-scheduler-volume-scheduler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:volume-scheduler
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.scheduler.name }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name:  {{ .Values.scheduler.name }}-extension-apiserver-authentication-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.scheduler.name }}
+  namespace: {{ .Release.Namespace }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.scheduler.name }}
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: scheduler-plugins
+    app.kubernetes.io/part-of: scheduler-plugins
+    {{- include "chart.labels" . | nindent 4 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,36 @@
+# Default values for chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+scheduler:
+  name: llmaz-scheduler
+  image:
+    repository: inftyai/kube-scheduler
+    tag: v0.0.1
+    pullPolicy: IfNotPresent
+  command:
+  - /kube-scheduler
+  replicaCount: 1
+  leaderElect: false
+  priorityClassName: ""
+  resources: {}
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
+
+plugins:
+  enabled:
+  - name: ResourceFungibility
+    weight: 10 # make sure this plugin dominates the scheduling since GPU is scarce
+  disabled: [] # only in-tree plugins need to be defined here
+
+# Customize the enabled plugins' config.
+# Refer to the "pluginConfig" section of manifests/<plugin>/scheduler-config.yaml.
+# For example, for ResourceFungibility plugin, like below:
+pluginConfig:
+# - name: ResourceFungibility
+#   args:
+#
+# Or, customize the other plugins
+# ...


### PR DESCRIPTION
Test:

```
(base) ➜  scheduler-plugins git:(install-as-a-second-scheduler) helm upgrade --install llmaz-scheduler --set scheduler.image.repository=ghcr.io/carlory/inftyai/scheduler-plugins --set scheduler.image.tag=latest  ./chart
Release "llmaz-scheduler" has been upgraded. Happy Helming!
NAME: llmaz-scheduler
LAST DEPLOYED: Thu May 29 18:11:25 2025
NAMESPACE: default
STATUS: deployed
REVISION: 9
TEST SUITE: None

(base) ➜  scheduler-plugins git:(install-as-a-second-scheduler) kubectl get po
NAME                                                            READY   STATUS    RESTARTS   AGE
llmaz-scheduler-6899f8dc7d-fljfj                                1/1     Running   0          8m15s

(base) ➜  scheduler-plugins git:(install-as-a-second-scheduler) kubectl get po -owide
NAME                                                            READY   STATUS    RESTARTS   AGE     IP            NODE                           NOMINATED NODE   READINESS GATES
llmaz-scheduler-6899f8dc7d-fljfj                                1/1     Running   0          9m15s   10.244.3.24   kind-worker                    <none>           <none>
qwen2-0--5b-demo-0                                              1/1     Running   0          5m50s   10.244.10.2   quirky-hofstadter-2901052955   <none>           <none>

(base) ➜  scheduler-plugins git:(install-as-a-second-scheduler) kubectl get openmodel qwen2-0--5b -oyaml
...
  inferenceConfig:
    flavors:
    - limits:
        cpu: 100m
        memory: 10Mi
      name: 0x
      nodeSelector:
        node.kubernetes.io/instance-type: c-0x-amd64-linux
    - limits:
        cpu: 100m
        memory: 10Mi
      name: 2x
      nodeSelector:
        node.kubernetes.io/instance-type: c-2x-amd64-linux
    - limits:
        cpu: 100m
        memory: 10Mi
      name: 1x
      nodeSelector:
        node.kubernetes.io/instance-type: c-1x-amd64-linux
...

(base) ➜  scheduler-plugins git:(install-as-a-second-scheduler) kubectl get po qwen2-0--5b-demo-0 -oya
ml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    leaderworkerset.sigs.k8s.io/size: "1"
    llmaz.io/inference-service-flavors: 1x

(base) ➜  scheduler-plugins git:(install-as-a-second-scheduler) kubectl get nodeclaim
NAME            TYPE               CAPACITY   ZONE          NODE                           READY   AGE
default-tgf4f   c-1x-amd64-linux   spot       test-zone-a   quirky-hofstadter-2901052955   True    3h56m
```