### PR TITLE
Fix Makefile: Add build args to docker-buildx target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name project-v3-builder
 	$(CONTAINER_TOOL) buildx use project-v3-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
+	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) --build-arg CGO_ENABLED=$(CGO_ENABLED) $(IMAGE_BUILD_EXTRA_OPTS) -f Dockerfile.cross .
 	- $(CONTAINER_TOOL) buildx rm project-v3-builder
 	rm Dockerfile.cross
 


### PR DESCRIPTION
```
Dockerfile.cross:5
--------------------
   3 |
   4 |     # Build the manager binary
   5 | >>> FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
   6 |     ARG TARGETOS
   7 |     ARG TARGETARCH
--------------------
ERROR: failed to solve: base name (${BUILDER_IMAGE}) should not be blank
```

Test with this PR:

```
(base) ➜  scheduler-plugins git:(isvc) IMG=ghcr.io/carlory/inftyai/scheduler-plugins make docker-buildx
Makefile:205: warning: overriding commands for target `/Users/kiki/workspace/golang/src/github.com/inftyai/scheduler-plugins/bin'
Makefile:44: warning: ignoring old commands for target `/Users/kiki/workspace/golang/src/github.com/inftyai/scheduler-plugins/bin'
# copy existing Dockerfile and insert --platform= into Dockerfile.cross, and preserve the original Dockerfile
sed -e '1 s/\(^FROM\)/FROM --platform=\$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
docker buildx create --name project-v3-builder
project-v3-builder
docker buildx use project-v3-builder
docker buildx build --push --platform=linux/arm64,linux/amd64,linux/s390x,linux/ppc64le --tag ghcr.io/carlory/inftyai/scheduler-plugins --build-arg BASE_IMAGE=gcr.io/distroless/static:nonroot --build-arg BUILDER_IMAGE=golang:1.24.1 --build-arg CGO_ENABLED=  -f Dockerfile.cross .
[+] Building 1142.1s (44/44) FINISHED                                                               docker-container:project-v3-builder
...
docker buildx rm project-v3-builder
project-v3-builder removed
rm Dockerfile.cross
```